### PR TITLE
Add location option

### DIFF
--- a/lib/terminal-view.js
+++ b/lib/terminal-view.js
@@ -141,7 +141,7 @@ export default class TerminalView {
   }
 
   getDefaultLocation() {
-    return 'bottom';
+    return atom.config.get('terminal-tab.defaultLocation');
   }
 
   getIconName() {

--- a/lib/terminal.js
+++ b/lib/terminal.js
@@ -48,6 +48,13 @@ export default {
           return '';
         }
       })()
+    },
+    defaultLocation: {
+      title: 'Default Location',
+      description: 'Where to open new terminals',
+      type: 'string',
+      default: 'bottom',
+      enum: [ 'bottom', 'left', 'right', 'center' ]
     }
   },
 


### PR DESCRIPTION
I wanted to have the terminal open in a normal tab, and luckily
getDefaultLocation supports 'center' for that, plus a few more values:

- http://blog.atom.io/2017/05/16/atom-1-17.html

Fixes #17.