### PR TITLE
Use process.env for spawned terminal's environment

### DIFF
--- a/lib/terminal-view.js
+++ b/lib/terminal-view.js
@@ -119,7 +119,7 @@ export default class TerminalView {
     return spawnPty(process.env.SHELL, [], {
       name: 'xterm-color',
       cwd: path.resolve(workingDirectory),
-      env: {}
+      env: process.env
     });
   }
 


### PR DESCRIPTION
Fixes #35.  `process.env` should be used as the spawned terminal's environment so that the user's environment variables (like PATH, profile settings, etc) get carried forward.  Could potentially add a setting for this too if you want.