### PR TITLE
Add shellPath and shellArgs settings

### DIFF
--- a/lib/terminal-view.js
+++ b/lib/terminal-view.js
@@ -108,15 +108,6 @@ export default class TerminalView {
     let shellArgsString = atom.config.get('atom-terminal-tab.shellArgs') || '';
     let shellArgs = shellArgsString.split(/\s+/g).filter(arg => arg);
 
-    if (process.platform === "darwin" || process.platform === "linux") {
-      if (shellPath === "/bin/bash") {
-        // Start a login shell so that the user's bash profile gets used
-        if (shellArgs.indexOf('--login') == -1 && shellArgs.indexOf('-l') == -1) {
-          shellArgs.push('--login')
-        }
-      }
-    }
-
     return spawnPty(shellPath, shellArgs, {
       name: 'xterm-color',
       cwd: path.resolve(workingDirectory),

--- a/lib/terminal-view.js
+++ b/lib/terminal-view.js
@@ -104,7 +104,20 @@ export default class TerminalView {
       workingDirectory = projectPaths[0];
     }
 
-    return spawnPty(process.env.SHELL, [], {
+    let shellPath = atom.config.get('atom-terminal-tab.shellPath') || process.env.SHELL || process.env.COMSPEC;
+    let shellArgsString = atom.config.get('atom-terminal-tab.shellArgs') || '';
+    let shellArgs = shellArgsString.split(/\s+/g).filter(arg => arg);
+
+    if (process.platform === "darwin" || process.platform === "linux") {
+      if (shellPath === "/bin/bash") {
+        // Start a login shell so that the user's bash profile gets used
+        if (shellArgs.indexOf('--login') == -1 && shellArgs.indexOf('-l') == -1) {
+          shellArgs.push('--login')
+        }
+      }
+    }
+
+    return spawnPty(shellPath, shellArgs, {
       name: 'xterm-color',
       cwd: path.resolve(workingDirectory),
       env: this.sanitizedEnvironment

--- a/lib/terminal.js
+++ b/lib/terminal.js
@@ -22,6 +22,18 @@ export default {
       description: 'Specify environment variables to unset in terminal sessions (e.g. NODE_ENV).',
       type: 'array',
       default: [ 'NODE_ENV' ]
+    },
+    shellPath: {
+      title: 'Shell Application Path',
+      description: 'Path to your shell application.  Uses $SHELL environment variable by default on *NIX and %COMSPEC% on Windows.',
+      type: 'string',
+      default: ''
+    },
+    shellArgs: {
+      title: 'Shell Application Arguments',
+      description: 'Arguments to send to the shell application on launch.  Sends "-l" by default on *NIX and nothing on Windows.',
+      type: 'string',
+      default: ''
     }
   },
 

--- a/lib/terminal.js
+++ b/lib/terminal.js
@@ -27,13 +27,27 @@ export default {
       title: 'Shell Application Path',
       description: 'Path to your shell application.  Uses $SHELL environment variable by default on *NIX and %COMSPEC% on Windows.',
       type: 'string',
-      default: ''
+      default: (function() {
+        if (process.platform === 'win32') {
+          return process.env.COMSPEC || 'cmd.exe';
+        }
+        else {
+          return process.env.SHELL || '/bin/bash';
+        }
+      })()
     },
     shellArgs: {
       title: 'Shell Application Arguments',
       description: 'Arguments to send to the shell application on launch.  Sends "-l" by default on *NIX and nothing on Windows.',
       type: 'string',
-      default: ''
+      default: (function() {
+        if (process.platform !== "win32" && process.env.SHELL === "/bin/bash") {
+          return '--login';
+        }
+        else {
+          return '';
+        }
+      })()
     }
   },
 


### PR DESCRIPTION
This change also adds a `--login` argument by default on Linux and
macOS machines when bash is used as the shell.  This brings the
user's bash profile into the session.

Related to #35 and #36.