### PR TITLE
Guard against empty sanitizeEnvironment setting

### DIFF
--- a/lib/terminal-view.js
+++ b/lib/terminal-view.js
@@ -180,9 +180,11 @@ export default class TerminalView {
     const sanitizedEnvironment = Object.assign({}, process.env);
     const variablesToDelete = atom.config.get('atom-terminal-tab.sanitizeEnvironment');
 
-    variablesToDelete.forEach((variable) => {
-      delete sanitizedEnvironment[variable];
-    });
+    if (variablesToDelete) {
+      variablesToDelete.forEach((variable) => {
+        delete sanitizedEnvironment[variable];
+      });
+    }
 
     return sanitizedEnvironment;
   }


### PR DESCRIPTION
This code was causing a CI failure, probably due to this setting not
being populated by Atom APIs when running in CI.  It also hangs Atom
completely when deserializing a TerminalView at Atom startup.  To
repro, create a terminal tab and reload the Atom window while the tab
is still open.