### PR TITLE
Add linux/windows keybindings

### DIFF
--- a/keymaps/terminal.json
+++ b/keymaps/terminal.json
@@ -5,22 +5,22 @@
   ".platform-darwin terminal-view": {
     "cmd-c": "terminal:copy",
     "cmd-v": "terminal:paste",
-    "cmd-k": "terminal:clear"
+    "cmd-shift-k": "terminal:clear"
   },
   ".platform-win32 atom-workspace": {
     "alt-shift-t": "terminal:open"
   },
   ".platform-win32 terminal-view": {
-    "ctrl-c": "terminal:copy",
-    "ctrl-v": "terminal:paste",
-    "ctrl-k": "terminal:clear"
+    "ctrl-shift-c": "terminal:copy",
+    "ctrl-shift-v": "terminal:paste",
+    "ctrl-shift-k": "terminal:clear"
   },
   ".platform-linux atom-workspace": {
     "alt-shift-t": "terminal:open"
   },
   ".platform-linux terminal-view": {
-    "ctrl-c": "terminal:copy",
-    "ctrl-v": "terminal:paste",
-    "ctrl-k": "terminal:clear"
+    "ctrl-shift-c": "terminal:copy",
+    "ctrl-shift-v": "terminal:paste",
+    "ctrl-shift-k": "terminal:clear"
   }
 }

--- a/keymaps/terminal.json
+++ b/keymaps/terminal.json
@@ -1,9 +1,26 @@
 {
-  "atom-workspace": {
+  ".platform-darwin atom-workspace": {
     "cmd-shift-t": "terminal:open"
   },
-  "terminal-view": {
+  ".platform-darwin terminal-view": {
     "cmd-c": "terminal:copy",
-    "cmd-v": "terminal:paste"
+    "cmd-v": "terminal:paste",
+    "cmd-k": "terminal:clear"
+  },
+  ".platform-win32 atom-workspace": {
+    "alt-shift-t": "terminal:open"
+  },
+  ".platform-win32 terminal-view": {
+    "ctrl-c": "terminal:copy",
+    "ctrl-v": "terminal:paste",
+    "ctrl-k": "terminal:clear"
+  },
+  ".platform-linux atom-workspace": {
+    "alt-shift-t": "terminal:open"
+  },
+  ".platform-linux terminal-view": {
+    "ctrl-c": "terminal:copy",
+    "ctrl-v": "terminal:paste",
+    "ctrl-k": "terminal:clear"
   }
 }

--- a/keymaps/terminal.json
+++ b/keymaps/terminal.json
@@ -4,7 +4,6 @@
   },
   "terminal-view": {
     "cmd-c": "terminal:copy",
-    "cmd-v": "terminal:paste",
-    "cmd-k": "terminal:clear"
+    "cmd-v": "terminal:paste"
   }
 }


### PR DESCRIPTION
Add alt-shift-t keybinding to open terminal.
It allows non mac user to open terminal with keybinding.

It could help with #6 if we remove cmd-shift-t.