### PR TITLE
Use node-pty-prebuilt to avoid building node-pty

### DIFF
--- a/lib/terminal-view.js
+++ b/lib/terminal-view.js
@@ -4,7 +4,7 @@ import { CompositeDisposable } from 'atom';
 import ResizeObserver from 'resize-observer-polyfill';
 import Terminal from 'xterm';
 import path from 'path';
-import { spawn as spawnPty } from 'node-pty';
+import { spawn as spawnPty } from 'node-pty-prebuilt';
 
 Terminal.loadAddon('fit');
 

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "atom": ">=1.16.0 <2.0.0"
   },
   "dependencies": {
-    "node-pty": "^0.7.3",
+    "node-pty-prebuilt": "^0.7.3",
     "resize-observer-polyfill": "^1.5.0",
     "xterm": "^2.9.2"
   },


### PR DESCRIPTION
This change uses the new [node-pty-prebuilt](https://github.com/daviwil/node-pty-prebuilt) package to leverage pre-built node-pty binaries for Windows, macOS and Linux.