### PR TITLE
Upgrade to Xterm 3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 * Prevented duplicate calls to `applyThemeStyles` when opening new tabs.
 * Reimplemented etch on `TerminalView`.
 * Extracted business logic from `TerminalView` into a new `TerminalSession` model.
+* Updated to Xterm 3.
 
 ## 0.4.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 * Reimplemented etch on `TerminalView`.
 * Extracted business logic from `TerminalView` into a new `TerminalSession` model.
 * Updated to Xterm 3.
+* Refactored the theme matching logic into a new `ThemeMatcher` class, which creates a DOM tree to read Atom styles from using `getComputedStyle()`.
 
 ## 0.4.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Extracted business logic from `TerminalView` into a new `TerminalSession` model.
 * Updated to Xterm 3.1.
 * Refactored the theme matching logic into a new `ThemeMatcher` class, which creates a DOM tree to read Atom styles from using `getComputedStyle()`.
+* Added spacing and proper sizing logic to ensure that the terminal consumes all available space in its container.
 
 ## 0.4.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 * Prevented duplicate calls to `applyThemeStyles` when opening new tabs.
 * Reimplemented etch on `TerminalView`.
 * Extracted business logic from `TerminalView` into a new `TerminalSession` model.
-* Updated to Xterm 3.
+* Updated to Xterm 3.1.
 * Refactored the theme matching logic into a new `ThemeMatcher` class, which creates a DOM tree to read Atom styles from using `getComputedStyle()`.
 
 ## 0.4.0

--- a/lib/terminal-session.js
+++ b/lib/terminal-session.js
@@ -2,10 +2,8 @@
 
 import { CompositeDisposable, Emitter } from 'atom';
 import { spawn as spawnPty } from 'node-pty-prebuilt';
-import Xterm from 'xterm';
+import { Terminal as Xterm } from 'xterm';
 import path from 'path';
-
-Xterm.loadAddon('fit');
 
 //
 // Terminal Session

--- a/lib/terminal-view.js
+++ b/lib/terminal-view.js
@@ -129,17 +129,17 @@ export default class TerminalView {
   //
   applyThemeStyles() {
 
+    // Bail out if the user has not requested to match the theme styles
+    if (!atom.config.get('terminal-tab.matchTheme')) {
+      this.session.xterm.setOption('theme', {});
+      return;
+    }
+
     const themeStyles = ThemeMatcher.parseThemeStyles();
     console.log('Theme Styles: ', themeStyles);
 
     this.session.xterm.setOption('theme', themeStyles);
 
-    // Bail out if the user has not requested to match the theme styles
-    // if (!atom.config.get('terminal-tab.matchTheme')) {
-    //   this.element.classList.remove('themed');
-    //   return;
-    // }
-    //
     // this.element.classList.add('themed');
     //
     // const xtermElement = this.session.xterm.element;

--- a/lib/terminal-view.js
+++ b/lib/terminal-view.js
@@ -118,9 +118,11 @@ export default class TerminalView {
   // for the first time.
   //
   observeAndApplyThemeStyles() {
-    if (typeof this._applyThemeStylesObserver !== 'undefined') return;
-    this._applyThemeStylesObserver = atom.config.observe('terminal-tab.matchTheme', this.applyThemeStyles.bind(this));
-    this.disposables.add(this._applyThemeStylesObserver);
+    if (this.isObservingThemeSettings) return;
+    this.disposables.add(atom.config.onDidChange('terminal-tab.matchTheme', this.applyThemeStyles.bind(this)));
+    this.disposables.add(atom.themes.onDidChangeActiveThemes(this.applyThemeStyles.bind(this)));
+    this.isObservingThemeSettings = true;
+    this.applyThemeStyles();
   }
 
   //

--- a/lib/terminal-view.js
+++ b/lib/terminal-view.js
@@ -5,6 +5,7 @@ import { CompositeDisposable } from 'atom';
 import ResizeObserver from 'resize-observer-polyfill';
 import * as fit from 'xterm/lib/addons/fit/fit';
 import etch from 'etch';
+import ThemeMatcher from './theme-matcher';
 
 export default class TerminalView {
 
@@ -50,7 +51,8 @@ export default class TerminalView {
   openTerminal() {
     this.session.xterm.open(this.element);
     this.session.xterm.focus();
-    // this.observeAndApplyThemeStyles();
+
+    this.observeAndApplyThemeStyles();
   }
 
   //
@@ -112,27 +114,33 @@ export default class TerminalView {
   // TODO: This doesn't undo the font settings when the theme is disabled...
   //
   applyThemeStyles() {
+
+    const themeStyles = ThemeMatcher.parseThemeStyles();
+    console.log('Theme Styles: ', themeStyles);
+
+    this.session.xterm.setOption('theme', themeStyles);
+
     // Bail out if the user has not requested to match the theme styles
-    if (!atom.config.get('terminal-tab.matchTheme')) {
-      this.element.classList.remove('themed');
-      return;
-    }
-
-    this.element.classList.add('themed');
-
-    const xtermElement = this.session.xterm.element;
-    if (typeof atom.config.settings.editor !== 'undefined') {
-      if (typeof atom.config.settings.editor.fontSize !== 'undefined')
-        xtermElement.style.fontSize = `${atom.config.settings.editor.fontSize}px`;
-      if (typeof atom.config.settings.editor.fontFamily !== 'undefined')
-        xtermElement.style.fontFamily = atom.config.settings.editor.fontFamily;
-      // if (typeof atom.config.settings.editor.lineHeight !== 'undefined')
-      //   xtermElement.style.lineHeight = atom.config.settings.editor.lineHeight;
-    }
-
-    // TODO: We need to call this when the user changes the setting, but it is being called twice on first initialization.
-    // TODO: We could move this to update()...?
-    // fit.fit(this.session.xterm);
+    // if (!atom.config.get('terminal-tab.matchTheme')) {
+    //   this.element.classList.remove('themed');
+    //   return;
+    // }
+    //
+    // this.element.classList.add('themed');
+    //
+    // const xtermElement = this.session.xterm.element;
+    // if (typeof atom.config.settings.editor !== 'undefined') {
+    //   if (typeof atom.config.settings.editor.fontSize !== 'undefined')
+    //     xtermElement.style.fontSize = `${atom.config.settings.editor.fontSize}px`;
+    //   if (typeof atom.config.settings.editor.fontFamily !== 'undefined')
+    //     xtermElement.style.fontFamily = atom.config.settings.editor.fontFamily;
+    //   // if (typeof atom.config.settings.editor.lineHeight !== 'undefined')
+    //   //   xtermElement.style.lineHeight = atom.config.settings.editor.lineHeight;
+    // }
+    //
+    // // TODO: We need to call this when the user changes the setting, but it is being called twice on first initialization.
+    // // TODO: We could move this to update()...?
+    // // fit.fit(this.session.xterm);
   }
 
 }

--- a/lib/terminal-view.js
+++ b/lib/terminal-view.js
@@ -25,7 +25,6 @@ export default class TerminalView {
     // etch.setScheduler(atom.views);
     etch.initialize(this);
 
-    // this.openTerminal();
     this.observeResizeEvents();
   }
 

--- a/lib/terminal-view.js
+++ b/lib/terminal-view.js
@@ -55,6 +55,7 @@ export default class TerminalView {
     this.session.xterm.focus();
 
     this.observeAndApplyThemeStyles();
+    this.observeAndApplyTypeSettings();
   }
 
   //
@@ -77,6 +78,7 @@ export default class TerminalView {
       this.openTerminal();
     }
 
+    // TODO: Move this to resizeTerminalToFitContainer()
     if (this.session && this.session.pty && this.session.xterm) {
 
       // Set padding and resize the terminal to fit its container (as best as possible)
@@ -122,6 +124,20 @@ export default class TerminalView {
   }
 
   //
+  // Observe for changes to the Editor configuration for Atom and apply
+  // the type settings when the values we are interested in change. This
+  // will also apply them when called for the first time.
+  //
+  observeAndApplyTypeSettings() {
+    if (this.isObservingTypeSettings) return;
+    this.disposables.add(atom.config.onDidChange('editor.fontFamily', this.applyTypeSettings.bind(this)));
+    this.disposables.add(atom.config.onDidChange('editor.fontSize', this.applyTypeSettings.bind(this)));
+    this.disposables.add(atom.config.onDidChange('editor.lineHeight', this.applyTypeSettings.bind(this)));
+    this.isObservingTypeSettings = true;
+    this.applyTypeSettings();
+  }
+
+  //
   // Attempts to match the Xterm instance with the current Atom theme colors.
   //
   // TODO: This should take advantage of update()
@@ -135,26 +151,54 @@ export default class TerminalView {
       return;
     }
 
+    // Parse the Atom theme styles and configure the Xterm to match.
     const themeStyles = ThemeMatcher.parseThemeStyles();
-    console.log('Theme Styles: ', themeStyles);
-
     this.session.xterm.setOption('theme', themeStyles);
 
-    // this.element.classList.add('themed');
+  }
+
+  //
+  // Attempts to match the Atom type settings (font family, size and line height) with
+  // Xterm.
+  //
+  applyTypeSettings() {
+
     //
-    // const xtermElement = this.session.xterm.element;
-    // if (typeof atom.config.settings.editor !== 'undefined') {
-    //   if (typeof atom.config.settings.editor.fontSize !== 'undefined')
-    //     xtermElement.style.fontSize = `${atom.config.settings.editor.fontSize}px`;
-    //   if (typeof atom.config.settings.editor.fontFamily !== 'undefined')
-    //     xtermElement.style.fontFamily = atom.config.settings.editor.fontFamily;
-    //   // if (typeof atom.config.settings.editor.lineHeight !== 'undefined')
-    //   //   xtermElement.style.lineHeight = atom.config.settings.editor.lineHeight;
-    // }
+    // Set the font family in Xterm to match Atom.
     //
-    // // TODO: We need to call this when the user changes the setting, but it is being called twice on first initialization.
-    // // TODO: We could move this to update()...?
-    // // fit.fit(this.session.xterm);
+    let fontFamily = atom.config.get('editor.fontFamily');
+    if (fontFamily) {
+      this.session.xterm.setOption('fontFamily', fontFamily);
+    } else {
+      this.session.xterm.setOption('fontFamily', 'Menlo, Consolas, "DejaVu Sans Mono", monospace');
+    }
+
+    //
+    // Set the font size in Xterm to match Atom.
+    //
+    const fontSize = atom.config.get('editor.fontSize');
+    this.session.xterm.setOption('fontSize', fontSize);
+
+    //
+    // Set the line height in Xterm to match Atom.
+    //
+    // TODO: This is disabled, because the line height as specified in
+    //       Atom is not the same as what Xterm is using to render its
+    //       lines (i.e. 1.5 in Atom is more like 2x in Xterm). Need to
+    //       figure out the correct conversion or fix the bug, if there
+    //       is one.
+    //
+    // const lineHeight = atom.config.get('editor.lineHeight');
+    // this.session.xterm.setOption('lineHeight', lineHeight);
+
+    //
+    // Changing the font size and/or line height requires that we
+    // recalcuate the size of the Xterm instance.
+    //
+    // TODO: Call the renamed method (i.e. resizeTerminalToFitContainer())
+    //
+    this.didResize();
+
   }
 
 }

--- a/lib/terminal-view.js
+++ b/lib/terminal-view.js
@@ -3,6 +3,7 @@
 
 import { CompositeDisposable } from 'atom';
 import ResizeObserver from 'resize-observer-polyfill';
+import * as fit from 'xterm/lib/addons/fit/fit';
 import etch from 'etch';
 
 export default class TerminalView {
@@ -21,7 +22,7 @@ export default class TerminalView {
     // etch.setScheduler(atom.views);
     etch.initialize(this);
 
-    this.openTerminal();
+    // this.openTerminal();
     this.observeResizeEvents();
   }
 
@@ -47,11 +48,9 @@ export default class TerminalView {
   // focus and resize it to fit its viewport.
   //
   openTerminal() {
-    this.session.xterm.open(this.element, true);
-    this.observeAndApplyThemeStyles();
-
-    // TODO: Move this.session.xterm.fit() to update()? Can we rely strictly on the ResizeObserver?
-    this.session.xterm.fit();
+    this.session.xterm.open(this.element);
+    this.session.xterm.focus();
+    // this.observeAndApplyThemeStyles();
   }
 
   //
@@ -70,10 +69,14 @@ export default class TerminalView {
   // the pseudoterminal (pty) to remain consistent.
   //
   didResize() {
+    if (!this.session.xterm.element) {
+      this.openTerminal();
+    }
+
     if (this.session && this.session.pty && this.session.xterm) {
 
       // Resize Terminal to Container
-      this.session.xterm.fit();
+      fit.fit(this.session.xterm);
 
       // Update Pseudoterminal Process w/New Dimensions
       this.session.pty.resize(this.session.xterm.cols, this.session.xterm.rows);
@@ -129,7 +132,7 @@ export default class TerminalView {
 
     // TODO: We need to call this when the user changes the setting, but it is being called twice on first initialization.
     // TODO: We could move this to update()...?
-    this.session.xterm.fit();
+    // fit.fit(this.session.xterm);
   }
 
 }

--- a/lib/terminal-view.js
+++ b/lib/terminal-view.js
@@ -7,6 +7,8 @@ import * as fit from 'xterm/lib/addons/fit/fit';
 import etch from 'etch';
 import ThemeMatcher from './theme-matcher';
 
+const TERMINAL_PADDING = 5;
+
 export default class TerminalView {
 
   constructor(session) {
@@ -77,7 +79,19 @@ export default class TerminalView {
 
     if (this.session && this.session.pty && this.session.xterm) {
 
-      // Resize Terminal to Container
+      // Set padding and resize the terminal to fit its container (as best as possible)
+      this.session.xterm.element.style.padding = `${TERMINAL_PADDING}px`;
+      fit.fit(this.session.xterm);
+
+      // Check the new size and add additional padding to the top of the
+      // terminal so that it fills all available space.
+      // TODO: Extract this into a new calculatePadding() or something...
+      const elementStyles = getComputedStyle(this.element);
+      const xtermElementStyles = getComputedStyle(this.session.xterm.element);
+      const elementHeight = parseInt(elementStyles.height, 10);
+      const xtermHeight = parseInt(xtermElementStyles.height, 10);
+      const newHeight = elementHeight - xtermHeight + TERMINAL_PADDING;
+      this.session.xterm.element.style.paddingTop = `${newHeight}px`;
       fit.fit(this.session.xterm);
 
       // Update Pseudoterminal Process w/New Dimensions

--- a/lib/theme-matcher.js
+++ b/lib/theme-matcher.js
@@ -44,10 +44,16 @@ export default class ThemeMatcher {
     return colors;
   }
 
+  cleanup() {
+    this.colorElements.remove();
+  }
+
   static parseThemeStyles() {
     const themeMatcher = new this();
     themeMatcher.writeElements();
-    return themeMatcher.readStyles();
+    const themeColors = themeMatcher.readStyles();
+    themeMatcher.cleanup();
+    return themeColors;
   }
 
 }

--- a/lib/theme-matcher.js
+++ b/lib/theme-matcher.js
@@ -1,0 +1,53 @@
+/** @babel */
+
+// TODO: Atom has a wonderful Color class (https://atom.io/docs/api/v1.23.3/Color), but I can't figure out how to import it directly... It's not exported: https://github.com/atom/atom/blob/ff6dc42fcd7d533cf4f50b2874e09cce24c77c28/exports/atom.js
+import rgbHex from 'rgb-hex';
+
+// TODO: Selection is rendered in the canvas, and therefore isn't a straight
+//       "background color". It renders above text and needs alpha in order
+//       to see the text. Therefore, we can't simply take the selection
+//       color from Atom and set it here, because it will mask the actual
+//       text without alpha. If we make the selection color semi-transparent,
+//       the color won't match the original selection color from Atom.
+
+const COLOR_KEYS = [
+  'foreground', 'background', 'cursor', 'cursorAccent', /* 'selection', */ 'black',
+  'red', 'green', 'yellow', 'blue', 'magenta', 'cyan', 'white', 'brightBlack',
+  'brightRed', 'brightGreen', 'brightYellow', 'brightBlue', 'brightMagenta',
+  'brightCyan', 'brightWhite'
+];
+
+export default class ThemeMatcher {
+
+  writeElements() {
+    this.colorElements = document.createElement('div');
+    this.colorElements.classList.add('terminal-view-color-elements');
+
+    COLOR_KEYS.forEach((colorKey) => {
+      const colorElement = document.createElement('span');
+      colorElement.dataset.colorKey = colorKey;
+      this.colorElements.appendChild(colorElement);
+    });
+
+    document.body.appendChild(this.colorElements);
+  }
+
+  readStyles() {
+    const colors = {};
+
+    Array.from(this.colorElements.children).forEach((colorElement) => {
+      const colorKey = colorElement.dataset.colorKey;
+      const computedStyle = getComputedStyle(colorElement);
+      colors[colorKey] = `#${rgbHex(computedStyle.color)}`;
+    });
+
+    return colors;
+  }
+
+  static parseThemeStyles() {
+    const themeMatcher = new this();
+    themeMatcher.writeElements();
+    return themeMatcher.readStyles();
+  }
+
+}

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "etch": "^0.12.7",
     "node-pty-prebuilt": "^0.7.3",
     "resize-observer-polyfill": "^1.5.0",
-    "xterm": "^2.9.2"
+    "xterm": "^3.0.2"
   },
   "deserializers": {
     "TerminalSession": "deserializeTerminalSession"

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
   "dependencies": {
     "etch": "^0.12.7",
     "node-pty-prebuilt": "^0.7.3",
+    "rgb-hex": "^2.1.0",
     "resize-observer-polyfill": "^1.5.0",
     "xterm": "^3.1.0"
   },
@@ -72,8 +73,5 @@
         "always"
       ]
     }
-  },
-  "devDependencies": {
-    "rgb-hex": "^2.1.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "etch": "^0.12.7",
     "node-pty-prebuilt": "^0.7.3",
     "resize-observer-polyfill": "^1.5.0",
-    "xterm": "^3.0.2"
+    "xterm": "^3.1.0"
   },
   "deserializers": {
     "TerminalSession": "deserializeTerminalSession"

--- a/package.json
+++ b/package.json
@@ -72,5 +72,8 @@
         "always"
       ]
     }
+  },
+  "devDependencies": {
+    "rgb-hex": "^2.1.0"
   }
 }

--- a/spec/terminal-session-spec.js
+++ b/spec/terminal-session-spec.js
@@ -1,7 +1,7 @@
 /** @babel */
 
 import TerminalSession from '../lib/terminal-session';
-import Xterm from 'xterm';
+import { Terminal as Xterm } from 'xterm';
 
 describe('TerminalSession', () => {
 

--- a/spec/terminal-view-spec.js
+++ b/spec/terminal-view-spec.js
@@ -11,6 +11,7 @@ describe('TerminalView', () => {
     terminalView = new TerminalView(testSession);
 
     jasmine.attachToDOM(terminalView.element);
+    terminalView.openTerminal();
   });
 
   afterEach(() => {

--- a/styles/terminal.less
+++ b/styles/terminal.less
@@ -14,6 +14,17 @@ terminal-view {
     font-family: Menlo, Consolas, 'DejaVu Sans Mono', monospace;
     font-size: 14px;
     line-height: normal;
+    position: absolute;
+    bottom: 0;
+    left: 0;
+    right: 0;
+  }
+
+  .xterm-viewport {
+    position: absolute;
+    bottom: 0;
+    left: 0;
+    right: 0;
   }
 
 }

--- a/styles/terminal.less
+++ b/styles/terminal.less
@@ -11,9 +11,6 @@
 terminal-view {
 
   .xterm {
-    font-family: Menlo, Consolas, 'DejaVu Sans Mono', monospace;
-    font-size: 14px;
-    line-height: normal;
     position: absolute;
     bottom: 0;
     left: 0;

--- a/styles/terminal.less
+++ b/styles/terminal.less
@@ -5,170 +5,103 @@
 // Import Styles from Xterm
 @import (inline) "../node_modules/xterm/dist/xterm.css";
 
-.ui-syntax-color() { @syntax-background-color: hsl(198,24%,20%); } .ui-syntax-color(); // fallback color
+.ui-syntax-color() { @syntax-background-color: hsl(198, 24%, 20%); } .ui-syntax-color(); // fallback color
 @ui-syntax-color: @syntax-background-color;
 
 terminal-view {
+
   .xterm {
     font-family: Menlo, Consolas, 'DejaVu Sans Mono', monospace;
     font-size: 14px;
     line-height: normal;
   }
 
-  &.themed .terminal {
-    background-color: @syntax-background-color;
+}
+
+.terminal-view-color-elements {
+
+  [data-color-key="foreground"] {
     color: @syntax-text-color;
-
-    .xterm-viewport {
-      background-color: @syntax-background-color;
-    }
-
-    &.focus {
-      .terminal-cursor:not(.xterm-cursor-style-underline):not(.xterm-cursor-style-bar) {
-        background-color: @syntax-text-color;
-      }
-    }
-
-    &:not(.focus) .terminal-cursor {
-      outline: 1px solid @syntax-text-color;
-      outline-offset: -1px;
-      background-color: transparent;
-    }
-
-    .xterm-color-0 {
-      color: #2e3436;
-    }
-
-    .xterm-bg-color-0 {
-      background-color: #2e3436;
-    }
-
-    .xterm-color-1 {
-      color: @syntax-color-variable; // Red
-    }
-
-    .xterm-bg-color-1 {
-      background-color: @syntax-color-variable; // Red
-    }
-
-    .xterm-color-2 {
-      color: @syntax-color-snippet; // Green
-    }
-
-    .xterm-bg-color-2 {
-      background-color: @syntax-color-snippet; // Green
-    }
-
-    .xterm-color-3 {
-      color: @syntax-color-constant; // Yellow (Orange)
-    }
-
-    .xterm-bg-color-3 {
-      background-color: @syntax-color-constant; // Yellow (Orange)
-    }
-
-    .xterm-color-4 {
-      color: @syntax-color-function; // Blue
-    }
-
-    .xterm-bg-color-4 {
-      background-color: @syntax-color-function; // Blue
-    }
-
-    .xterm-color-5 {
-      color: @syntax-color-keyword; // Purple
-    }
-
-    .xterm-bg-color-5 {
-      background-color: @syntax-color-keyword; // Purple
-    }
-
-    .xterm-color-6 {
-      color: @syntax-color-class; // Cyan
-    }
-
-    .xterm-bg-color-6 {
-      background-color: @syntax-color-class; // Cyan
-    }
-
-    .xterm-color-7 {
-      color: #d3d7cf;
-    }
-
-    .xterm-bg-color-7 {
-      background-color: #d3d7cf;
-    }
-
-    .xterm-color-8 {
-      color: #555753;
-    }
-
-    .xterm-bg-color-8 {
-      background-color: #555753;
-    }
-
-    .xterm-color-9 {
-      color: @syntax-color-variable; // Red
-    }
-
-    .xterm-bg-color-9 {
-      background-color: @syntax-color-variable; // Red
-    }
-
-    .xterm-color-10 {
-      color: @syntax-color-snippet; // Green
-    }
-
-    .xterm-bg-color-10 {
-      background-color: @syntax-color-snippet; // Green
-    }
-
-    .xterm-color-11 {
-      color: @syntax-color-constant; // Yellow (Orange)
-    }
-
-    .xterm-bg-color-11 {
-      background-color: @syntax-color-constant; // Yellow (Orange)
-    }
-
-    .xterm-color-12 {
-      color: @syntax-color-function; // Blue
-    }
-
-    .xterm-bg-color-12 {
-      background-color: @syntax-color-function; // Blue
-    }
-
-    .xterm-color-13 {
-      color: @syntax-color-keyword; // Purple
-    }
-
-    .xterm-bg-color-13 {
-      background-color: @syntax-color-keyword; // Purple
-    }
-
-    .xterm-color-14 {
-      color: @syntax-color-class; // Cyan
-    }
-
-    .xterm-bg-color-14 {
-      background-color: @syntax-color-class; // Cyan
-    }
-
-    .xterm-color-15 {
-      color: #eeeeec;
-    }
-
-    .xterm-bg-color-15 {
-      background-color: #eeeeec;
-    }
-
-    .xterm-color-16 {
-      color: #000000;
-    }
-
-    .xterm-bg-color-16 {
-      background-color: #000000;
-    }
   }
+
+  [data-color-key="background"] {
+    color: @syntax-background-color;
+  }
+
+  [data-color-key="cursor"] {
+    color: @syntax-text-color;
+  }
+
+  [data-color-key="cursorAccent"] {
+    color: @syntax-text-color;
+  }
+
+  [data-color-key="selection"] {
+    color: @syntax-selection-color;
+  }
+
+  [data-color-key="black"] { // 0, Black
+    color: #2e3436;
+  }
+
+  [data-color-key="red"] { // 1, Red
+    color: @syntax-color-variable;
+  }
+
+  [data-color-key="green"] { // 2, Green
+    color: @syntax-color-snippet;
+  }
+
+  [data-color-key="yellow"] { // 3, Yellow
+    color: @syntax-color-constant;
+  }
+
+  [data-color-key="blue"] { // 4, Blue
+    color: @syntax-color-function;
+  }
+
+  [data-color-key="magenta"] { // 5, Magenta
+    color: @syntax-color-keyword;
+  }
+
+  [data-color-key="cyan"] { // 6, Cyan
+    color: @syntax-color-class;
+  }
+
+  [data-color-key="white"] { // 7, White
+    color: #d3d7cf;
+  }
+
+  [data-color-key="brightBlack"] { // 8, Bright Black
+    color: #555753;
+  }
+
+  [data-color-key="brightRed"] { // 9, Bright Red
+    color: @syntax-color-variable;
+  }
+
+  [data-color-key="brightGreen"] { // 10, Bright Green
+    color: @syntax-color-snippet;
+  }
+
+  [data-color-key="brightYellow"] { // 11, Bright Yellow
+    color: @syntax-color-constant;
+  }
+
+  [data-color-key="brightBlue"] { // 12, Bright Blue
+    color: @syntax-color-function;
+  }
+
+  [data-color-key="brightMagenta"] { // 13, Bright Magenta
+    color: @syntax-color-keyword;
+  }
+
+  [data-color-key="brightCyan"] { // 14, Bright Cyan
+    color: @syntax-color-class;
+  }
+
+  [data-color-key="brightWhite"] { // 15, Bright White
+    color: #eeeeec;
+  }
+
 }


### PR DESCRIPTION
Updates the project to [Xterm 3.1](https://github.com/xtermjs/xterm.js/releases/tag/3.1.0).

### Changes

* Upgrades the project to use Xterm 3.1.
* Improves the display of terminal instances by ensuring that they fill the entire container space of their pane or tab. This also includes some default padding for better legibility.
* Matches the theme and font as closely as possible, albeit with a regression from master: selection color is not easily matched since the selection block is rendered in a canvas layer above the text, requiring a level of transparency to expose the underlying text. We can't simply map the selection color from the Atom theme, as it would need to be semi-transparent in order for text to be visible, and changing the alpha would result in a different color. For now, we're using the default text selection color from Xterm, but this is not optimal.
