### PR TITLE
Serialize Session Configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+* Improved serialization of terminal sessions so that the configuration in effect when a session is opened (i.e. shell path, arguments, etc) gets restored properly when reopening Atom.
+
 ## 0.5.0
 
 * Prevented duplicate calls to `applyThemeStyles` when opening new tabs.

--- a/lib/main.js
+++ b/lib/main.js
@@ -45,8 +45,8 @@ export default {
     this.disposables.dispose();
   },
 
-  deserializeTerminalSession(session) {
-    return new TerminalSession(session);
+  deserializeTerminalSession(data) {
+    return new TerminalSession(data.config);
   },
 
   handleOpen() {

--- a/lib/terminal-session.js
+++ b/lib/terminal-session.js
@@ -12,7 +12,8 @@ import path from 'path';
 //
 export default class TerminalSession {
 
-  constructor() {
+  constructor(config = {}) {
+    this.config = config;
     this.disposables = new CompositeDisposable();
     this.emitter = new Emitter();
     this.pty = this.openPseudoterminal();
@@ -44,11 +45,9 @@ export default class TerminalSession {
   }
 
   openPseudoterminal() {
-    const shellPath = atom.config.get('terminal-tab.shellPath') || process.env.SHELL || process.env.COMSPEC;
-    const shellArgsString = atom.config.get('terminal-tab.shellArgs') || '';
-    const shellArgs = shellArgsString.split(/\s+/g).filter(arg => arg);
+    const shellArguments = this.shellArguments.split(/\s+/g).filter(arg => arg);
 
-    return spawnPty(shellPath, shellArgs, {
+    return spawnPty(this.shellPath, shellArguments, {
       name: 'xterm-color',
       env: this.sanitizedEnvironment,
       cwd: this._getWorkingDirectory()
@@ -107,7 +106,12 @@ export default class TerminalSession {
 
   serialize() {
     return {
-      deserializer: 'TerminalSession'
+      deserializer: 'TerminalSession',
+      config: {
+        sanitizeEnvironment: this.sanitizeEnvironment,
+        shellArgs: this.shellArgs,
+        shellPath: this.shellPath
+      }
     };
   }
 
@@ -134,7 +138,7 @@ export default class TerminalSession {
 
   get sanitizedEnvironment() {
     const sanitizedEnvironment = Object.assign({}, process.env);
-    const variablesToDelete = atom.config.get('terminal-tab.sanitizeEnvironment');
+    const variablesToDelete = this.sanitizedEnvironmentKeys;
 
     if (variablesToDelete) {
       variablesToDelete.forEach((variable) => {
@@ -143,6 +147,27 @@ export default class TerminalSession {
     }
 
     return sanitizedEnvironment;
+  }
+
+  get shellPath() {
+    if (this._shellPath) return this._shellPath;
+    return this._shellPath = this.config.shellPath
+      || atom.config.get('terminal-tab.shellPath')
+      || process.env.SHELL
+      || process.env.COMSPEC;
+  }
+
+  get shellArguments() {
+    if (this._shellArguments) return this._shellArguments;
+    return this._shellArguments = this.config.shellArgs
+      || atom.config.get('terminal-tab.shellArgs')
+      || '';
+  }
+
+  get sanitizedEnvironmentKeys() {
+    if (this._sanitizedEnvironmentKeys) return this._sanitizedEnvironmentKeys;
+    return this._sanitizedEnvironmentKeys = this.config.sanitizeEnvironment
+      || atom.config.get('terminal-tab.sanitizeEnvironment');
   }
 
   getDefaultLocation() {


### PR DESCRIPTION
This allows us to restore the shell path, shell arguments and sanitized environment variables that were in effect at the time the session was started. It also fixes an issue wherein restored terminals were not using the default configuration variables, as the defaults are not yet loaded when deserializing.

This should resolve #46.