### PR TITLE
Allow Terminal URI opener accept a JSON-stringified config argument

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -24,8 +24,13 @@ export default {
 
     // Register Opener for the Terminal URI (`terminal-tab://`)
     this.disposables.add(atom.workspace.addOpener((uri) => {
-      if (uri === TERMINAL_TAB_URI) {
-        return new TerminalSession();
+      if (uri.startsWith(TERMINAL_TAB_URI)) {
+        let config = {};
+        const args = uri.substring(TERMINAL_TAB_URI.length);
+        if(args) {
+          config = JSON.parse(args);
+        }
+        return new TerminalSession(config);
       }
     }));
 


### PR DESCRIPTION
This allows other plugins to create terminal tabs by doing something like:

```js
atom.workspace.open(`terminal-tab:///${JSON.stringify({shellPath: pathToCustomShell})`);
```

This is a particularly interesting feature for Windows, where users sometimes use several different shells - Command Prompt, PowerShell, WSL, or Git Bash. Down the road, we could have a prompt command to create a terminal with a custom shell, as opposed to needing to manually reconfigure the default every time.