### PR TITLE
Adding focus / unfocus from terminals

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -46,6 +46,7 @@ export default {
 
   deactivate() {
     this.disposables.dispose();
+    this._closeTerminals();
   },
 
   deserializeTerminalSession(data) {
@@ -93,9 +94,19 @@ export default {
   // one that is a TerminalSession instance,
   // and returns one if found.
   _getOpenTerminal() {
-    for (let pane of atom.workspace.getPaneItems()) {
-      if (pane instanceof TerminalSession) {
-        return pane;
+    for (let item of atom.workspace.getPaneItems()) {
+      if (item instanceof TerminalSession) {
+        return item;
+      }
+    }
+  },
+
+  // close all active terminals
+  _closeTerminals() {
+    for (let item of atom.workspace.getPaneItems()) {
+      if (item instanceof TerminalSession) {
+        const pane = atom.workspace.paneForItem(item);
+        pane.destroy();
       }
     }
   }

--- a/lib/main.js
+++ b/lib/main.js
@@ -23,7 +23,6 @@ export default {
 
   deactivate() {
     this.disposables.dispose();
-    this._closeTerminals();
   },
 
   deserializeTerminalSession(data) {
@@ -35,13 +34,13 @@ export default {
   },
 
   handleFocus() {
-    const terminal = this._getOpenTerminal();
+    const terminal = this.getOpenTerminal();
     if (terminal) {
       const pane = atom.workspace.paneForItem(terminal);
       this.lastActivePane = atom.workspace.getActivePane();
       pane.activate();
     } else {
-      this.handleOpen();
+      return this.handleOpen();
     }
   },
 
@@ -70,20 +69,10 @@ export default {
   // Traverses all open panes and searches for
   // one that is a TerminalSession instance,
   // and returns one if found.
-  _getOpenTerminal() {
+  getOpenTerminal() {
     for (let item of atom.workspace.getPaneItems()) {
       if (item instanceof TerminalSession) {
         return item;
-      }
-    }
-  },
-
-  // close all active terminals
-  _closeTerminals() {
-    for (let item of atom.workspace.getPaneItems()) {
-      if (item instanceof TerminalSession) {
-        const pane = atom.workspace.paneForItem(item);
-        pane.destroy();
       }
     }
   },

--- a/lib/main.js
+++ b/lib/main.js
@@ -25,18 +25,21 @@ export default {
     // Register Opener for the Terminal URI (`terminal-tab://`)
     this.disposables.add(atom.workspace.addOpener((uri) => {
       if (uri === TERMINAL_TAB_URI) {
+        this.lastActivePane = atom.workspace.getActivePane();
         return new TerminalSession();
       }
-    }));
+    }.bind(this)));
 
     this.disposables.add(atom.commands.add('atom-workspace', {
-      'terminal:open': this.handleOpen.bind(this)
+      'terminal:open': this.handleOpen.bind(this),
+      'terminal:focus': this.handleFocus.bind(this),
     }));
 
     this.disposables.add(atom.commands.add('terminal-view', {
       'terminal:copy': this.handleCopy.bind(this),
       'terminal:paste': this.handlePaste.bind(this),
-      'terminal:clear': this.handleClear.bind(this)
+      'terminal:clear': this.handleClear.bind(this),
+      'terminal:unfocus': this.handleUnfocus.bind(this),
     }));
 
   },
@@ -53,6 +56,24 @@ export default {
     atom.workspace.open(TERMINAL_TAB_URI);
   },
 
+  handleFocus() {
+    const terminal = this._getOpenTerminal();
+    if (terminal) {
+      const pane = atom.workspace.paneForItem(terminal);
+      this.lastActivePane = atom.workspace.getActivePane();
+      pane.activate();
+    } else {
+      this.handleOpen();
+    }
+  },
+
+  handleUnfocus() {
+    if (this.lastActivePane) {
+      this.lastActivePane.activate();
+      this.lastActivePane = null;
+    }
+  },
+
   handleCopy() {
     const activeSession = atom.workspace.getActivePaneItem();
     activeSession.copySelection();
@@ -66,6 +87,17 @@ export default {
   handleClear() {
     const activeSession = atom.workspace.getActivePaneItem();
     activeSession.clear();
+  },
+
+  // Traverses all open panes and searches for
+  // one that is a TerminalSession instance,
+  // and returns one if found.
+  _getOpenTerminal() {
+    for (let pane of atom.workspace.getPaneItems()) {
+      if (pane instanceof TerminalSession) {
+        return pane;
+      }
+    }
   }
 
 };

--- a/spec/terminal-tab-spec.js
+++ b/spec/terminal-tab-spec.js
@@ -15,6 +15,12 @@ describe('TerminalTab', () => {
     activationPromise = atom.packages.activatePackage('terminal-tab');
   });
 
+  afterEach(() => {
+    waitsForPromise(() => {
+      return atom.packages.deactivatePackage('terminal-tab')
+    });
+  });
+
   describe('when the terminal:open event is triggered', () => {
 
     it('opens a new terminal', () => {

--- a/spec/terminal-tab-spec.js
+++ b/spec/terminal-tab-spec.js
@@ -125,7 +125,7 @@ describe('TerminalTab', () => {
   });
 
   describe('when the terminal:unfocus event is triggered', () => {
-    fit ('returns focus to the previously active panel', () => {
+    it ('returns focus to the previously active panel', () => {
         let originalActivePane = atom.workspace.getActivePane();
         let terminalView;
         terminalOpenAndWait(workspaceElement);

--- a/spec/terminal-tab-spec.js
+++ b/spec/terminal-tab-spec.js
@@ -7,12 +7,22 @@ import TerminalSession from '../lib/terminal-session';
 // To run a specific `it` or `describe` block add an `f` to the front (e.g. `fit`
 // or `fdescribe`). Remove the `f` to unfocus the block.
 
+function terminalOpenAndWait(workspaceElement) {
+    let terminalPromise = atom.commands.dispatch(workspaceElement, 'terminal:open');
+    waitsForPromise(() => {
+      return terminalPromise;
+    })
+}
+
 describe('TerminalTab', () => {
   let workspaceElement, activationPromise;
 
   beforeEach(() => {
     workspaceElement = atom.views.getView(atom.workspace);
     activationPromise = atom.packages.activatePackage('terminal-tab');
+    waitsForPromise(() => {
+      return activationPromise;
+    });
   });
 
   afterEach(() => {
@@ -28,15 +38,7 @@ describe('TerminalTab', () => {
       // Ensure that the terminal view element is not present in the workspace.
       expect(workspaceElement.querySelector('terminal-view')).not.toExist();
 
-      let terminalPromise = atom.commands.dispatch(workspaceElement, 'terminal:open');
-
-      waitsForPromise(() => {
-        return activationPromise;
-      });
-
-      waitsForPromise(() => {
-        return terminalPromise;
-      })
+      terminalOpenAndWait(workspaceElement);
 
       runs(() => {
         // Ensure that the terminal view element is present in the workspace.
@@ -56,5 +58,93 @@ describe('TerminalTab', () => {
 
     });
 
+  });
+
+  describe('when the terminal:focus event is triggered', () => {
+    it ('navigates to an open terminal', () => {
+      terminalOpenAndWait(workspaceElement);
+      let bottomDock = atom.workspace.getBottomDock();
+
+
+      runs(() => {
+        bottomDock.hide();
+        let terminalPromise = atom.commands.dispatch(workspaceElement, 'terminal:focus');
+        waitsForPromise(() => {
+          return terminalPromise;
+        });
+
+        // ensure the bottom dock is visible, and is the active item.
+        expect(bottomDock.isVisible()).toBe(true);
+
+        let activePaneItem = bottomDock.getActivePaneItem();
+        expect(activePaneItem).toBeInstanceOf(TerminalSession);
+
+        activePaneItem = atom.workspace.getActivePaneItem();
+        expect(activePaneItem).toBeInstanceOf(TerminalSession);
+      });
+    });
+
+    it ('opens and focuses a new terminal, if one does not exist', () => {
+      let bottomDock = atom.workspace.getBottomDock();
+      let terminalPromise = atom.commands.dispatch(workspaceElement, 'terminal:focus');
+      waitsForPromise(() => {
+        return terminalPromise;
+      });
+
+      runs(() => {
+        // ensure the bottom dock is visible, and is the active item.
+        expect(bottomDock.isVisible()).toBe(true);
+
+        let activePaneItem = bottomDock.getActivePaneItem();
+        expect(activePaneItem).toBeInstanceOf(TerminalSession);
+
+        activePaneItem = atom.workspace.getActivePaneItem();
+        expect(activePaneItem).toBeInstanceOf(TerminalSession);
+      });
+    });
+
+    it ('keeps focus if the terminal is already focused', () => {
+      terminalOpenAndWait(workspaceElement);
+
+      runs(() => {
+        activePaneItem = atom.workspace.getActivePaneItem();
+        expect(activePaneItem).toBeInstanceOf(TerminalSession);
+      });
+
+      let terminalPromise = atom.commands.dispatch(workspaceElement, 'terminal:focus');
+      waitsForPromise(() => {
+        return terminalPromise;
+      });
+
+      runs(() => {
+        activePaneItem = atom.workspace.getActivePaneItem();
+        expect(activePaneItem).toBeInstanceOf(TerminalSession);
+      });
+
+    });
+  });
+
+  describe('when the terminal:unfocus event is triggered', () => {
+    fit ('returns focus to the previously active panel', () => {
+        let originalActivePane = atom.workspace.getActivePane();
+        let terminalView;
+        terminalOpenAndWait(workspaceElement);
+
+        runs(() => {
+          expect(atom.workspace.getActivePane()).toNotBe(originalActivePane);
+          let activePaneItem = atom.workspace.getActivePaneItem();
+          expect(activePaneItem).toBeInstanceOf(TerminalSession);
+          terminalView = workspaceElement.querySelector('terminal-view');
+        });
+
+        waitsForPromise(() => {
+          let terminalPromise = atom.commands.dispatch(terminalView, 'terminal:unfocus');
+          return terminalPromise;
+        });
+
+        runs(() => {
+          expect(atom.workspace.getActivePane()).toBe(originalActivePane);
+        });
+    });
   });
 });


### PR DESCRIPTION
There's a neat feature in terminal-plus that allows you to focus and unfocus from the open terminal. This PR is a first draft at adding similar functionality to terminal-tab.

It's really nice from a workflow standpoint, since I can quickly open and focus a tab on demand. 

Open to any other suggestions on implementing this functionality as well. If this approach looks good, I can write some tests. 

