### PR TITLE
Fix race condition in terminal:open test

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -50,7 +50,7 @@ export default {
   },
 
   handleOpen() {
-    atom.workspace.open(TERMINAL_TAB_URI);
+    return atom.workspace.open(TERMINAL_TAB_URI);
   },
 
   handleCopy() {

--- a/spec/terminal-tab-spec.js
+++ b/spec/terminal-tab-spec.js
@@ -22,11 +22,15 @@ describe('TerminalTab', () => {
       // Ensure that the terminal view element is not present in the workspace.
       expect(workspaceElement.querySelector('terminal-view')).not.toExist();
 
-      atom.commands.dispatch(workspaceElement, 'terminal:open');
+      let terminalPromise = atom.commands.dispatch(workspaceElement, 'terminal:open');
 
       waitsForPromise(() => {
         return activationPromise;
       });
+
+      waitsForPromise(() => {
+        return terminalPromise;
+      })
 
       runs(() => {
         // Ensure that the terminal view element is present in the workspace.


### PR DESCRIPTION
There is no guarantee that the the terminal view element opens synchronously with the the command dispatcher. The command can return the promise that `atom.workspace.open` returns which propagates out to the test spec, which we can wait on.