### PR TITLE
Add service to allow other plugins to open terminal

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -49,6 +49,10 @@ export default {
     return new TerminalSession(data.config);
   },
 
+  provideTerminalSession() {
+    return (config={}) => atom.workspace.open(new TerminalSession(config));
+  },
+
   handleOpen() {
     atom.workspace.open(TERMINAL_TAB_URI);
   },

--- a/lib/terminal-session.js
+++ b/lib/terminal-session.js
@@ -61,6 +61,9 @@ export default class TerminalSession {
   // or the user's home directory.
   //
   _getWorkingDirectory() {
+    if(this.config.shellCwd) {
+      return this.config.shellCwd;
+    }
     const activeItem = atom.workspace.getActivePaneItem();
     if (activeItem
         && activeItem.buffer

--- a/package.json
+++ b/package.json
@@ -38,6 +38,14 @@
   "deserializers": {
     "TerminalSession": "deserializeTerminalSession"
   },
+  "providedServices": {
+    "terminal-tab": {
+      "description": "Create terminal-tab sessions",
+      "versions": {
+        "0.5.0": "provideTerminalSession"
+      }
+    }
+  },
   "eslintConfig": {
     "env": {
       "browser": true,


### PR DESCRIPTION
Closing #77 in favor of this.

This PR adds the ability to allow other plugins to consume a `terminal-tab` service and create Terminals using this plugin.

Some use cases:
- [ide-powershell](https://github.com/daviwil/ide-powershell) (uses a [fork of this plugin](https://github.com/daviwil/atom-terminal-tab) to consume a service to create a PowerShell console)
- [purduesigbots/pros-atom3](https://github.com/purduesigbots/pros-atom3) (would use this service to create a serial console to a microcontroller)