### PR TITLE
Add color to terminal

### DIFF
--- a/lib/terminal-session.js
+++ b/lib/terminal-session.js
@@ -43,7 +43,7 @@ export default class TerminalSession {
     const shellArguments = this.shellArguments.split(/\s+/g).filter(arg => arg);
 
     return spawnPty(this.shellPath, shellArguments, {
-      name: 'xterm-color',
+      name: 'xterm-256color',
       env: this.sanitizedEnvironment,
       cwd: this.workingDirectory
     });

--- a/lib/terminal-session.js
+++ b/lib/terminal-session.js
@@ -132,7 +132,8 @@ export default class TerminalSession {
   }
 
   get sanitizedEnvironment() {
-    const sanitizedEnvironment = Object.assign({}, process.env);
+    const variablesToInsert = this.insertableEnvironmentKeys;
+    const sanitizedEnvironment = Object.assign(variablesToInsert, process.env);
     const variablesToDelete = this.sanitizedEnvironmentKeys;
 
     if (variablesToDelete) {
@@ -163,6 +164,10 @@ export default class TerminalSession {
     if (this._sanitizedEnvironmentKeys) return this._sanitizedEnvironmentKeys;
     return this._sanitizedEnvironmentKeys = this.config.sanitizeEnvironment
       || atom.config.get('terminal-tab.shellSettings.sanitizeEnvironment');
+  }
+
+  get insertableEnvironmentKeys() {
+    return {COLORTERM: "truecolor"};
   }
 
   get workingDirectory() {


### PR DESCRIPTION
This is an implementation of #128. I tried to keep a consistent format. At this point`sanitizedEnvironment` may be better if it was renamed to `preparedEnvironment`.